### PR TITLE
Fix warning from gcc

### DIFF
--- a/smrenderd/smcache.c
+++ b/smrenderd/smcache.c
@@ -63,7 +63,9 @@ void qc_release(qcache_t *qc)
    qc->age = time(NULL);
    qc->ctr--;
    if (!qc->ctr)
+   {
       qc_signal(&cond_);
+   }
    qc_unlock(&mutex_);
 }
 


### PR DESCRIPTION
```
smrenderd/smcache.c:66:24: warning: suggest braces around empty body in an ‘if’ statement [-Wempty-body]
       qc_signal(&cond_);
```

Without WITH_THREADS qc_signal() is empty in smrenderd/smcache.h.
Since qc_unlock() is also empty, this luckily should work too before.