### PR TITLE
fix: allow with or height to be zero

### DIFF
--- a/src/smrender.c
+++ b/src/smrender.c
@@ -463,7 +463,7 @@ char *init_rd_paper(struct rdata *rd, const char *paper)
       } // end if
    } // end else
 
-   if ( (width <= 0.) || (height <= 0.) )  {
+   if ( ((width < 0.) || (height < 0.)) || ((width <= 0.) && (height <= 0.)) )  {
       log_msg(LOG_ERR, "page width and height must be a decimal value greater than 0"),
          exit(EXIT_FAILURE);
    } // end if


### PR DESCRIPTION
this is a fix for regression in: 9559551395

as for a fixed bounding box either width or height should be set 0:

  -P `width`x`height`