### PR TITLE
Fix st_mtim undefined on macOS

### DIFF
--- a/src/smindex.c
+++ b/src/smindex.c
@@ -51,6 +51,10 @@
 #define INDEX_VH_DSTS 0x44535453
 #define INDEX_VH_OBJS 0x4f424a53
 
+#if defined(__APPLE__)
+#define st_mtim st_mtimespec
+#endif
+
 
 typedef struct indexf
 {


### PR DESCRIPTION
This commit https://github.com/rahra/smrender/commit/1f618c3b6d54fcfd5dc7053853988b26529a04bd breaks build on macOS:
```sh
       > smindex.c:546:12: error: no member named 'st_mtim' in 'struct stat'
       >   546 |    ts = st.st_mtim;
       >       |         ~~ ^
       > smindex.c:571:25: error: no member named 'st_mtim' in 'struct stat'
       >   571 |    if (cmp_timespec(&st.st_mtim, &ts) < 0)
       >       |                      ~~ ^
```

See https://developer.apple.com/documentation/kernel/stat/1493575-st_mtimespec