### PR TITLE
Fix build with clang

### DIFF
--- a/src/smcore.h
+++ b/src/smcore.h
@@ -26,6 +26,8 @@
 #ifndef SMCORE_H
 #define SMCORE_H
 
+#include <pthread.h>
+
 #define NODES_FIRST 0
 #define RELS_FIRST 1
 


### PR DESCRIPTION
```
./smcore.h:66:4: error: unknown type name 'pthread_t'
   66 |    pthread_t thandle;      //!< thread handle
      |    ^
```